### PR TITLE
[flash_ctrl] [flash_ctrl] Add Test For The RMA Feature

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,6 +145,33 @@ jobs:
       includePatterns:
         - "/sw/***"
 
+- job: cw310_sw_build
+  displayName: Build Software required for CW310 FPGA synthesis
+  dependsOn: lint
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
+  pool:
+    vmImage: ubuntu-18.04
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - bash: |
+      set -x
+      sudo util/get-toolchain.py \
+        --install-dir="$TOOLCHAIN_PATH" \
+        --release-version="$TOOLCHAIN_VERSION" \
+        --update
+    displayName: Install toolchain
+  - bash: |
+      . util/build_consts.sh
+      ./meson_init.sh -A
+      ninja -C "$OBJ_DIR" \
+        sw/device/otp_img/otp_img_export_fpga_cw310 \
+        sw/device/lib/testing/test_rom/test_rom_export_fpga_cw310
+    displayName: Build embedded targets
+  - template: ci/upload-artifacts-template.yml
+    parameters:
+      includePatterns:
+        - "/sw/***"
+
 # Software targeting the Nexys Video board is produced by patching the source
 # tree before building. This produces a full sw build tree, however only the
 # artifacts with "nexysvideo" in the name are actually the ones we're looking
@@ -397,7 +424,7 @@ jobs:
   dependsOn:
     - lint
     # The bootrom is built into the FPGA image at synthesis time.
-    - sw_build
+    - cw310_sw_build
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
   pool: ci-public
   timeoutInMinutes: 120 # 2 hours
@@ -406,7 +433,7 @@ jobs:
   - template: ci/download-artifacts-template.yml
     parameters:
       downloadPartialBuildBinFrom:
-        - sw_build
+        - cw310_sw_build
   - bash: |
       set -e
       . util/build_consts.sh

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1952,7 +1952,7 @@
               some data.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_otbn_randomness"]
     }
     {
       name: chip_sw_otbn_urnd_entropy
@@ -1961,7 +1961,7 @@
             - Similar to chip_otbn_rnd_entropy, but verifies the URND bits.
             '''
       milestone: V2
-      tests: []
+      tests:  ["chip_sw_otbn_randomness"]
     }
     {
       name: chip_sw_otbn_idle

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -332,6 +332,13 @@
       sw_images: ["sw/device/tests/aon_timer_wdog_bite_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
+    }    
+    {
+      name: chip_sw_otbn_randomness
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/otbn_randomness_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
       name: chip_sw_kmac_mode_cshake_test

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -62,8 +62,8 @@ bool test_main() {
   if (rv != 0) {
     uint32_t fail_idx;
     CHECK(otbn_copy_data_from_otbn(&otbn_ctx, /*len_bytes=*/4, kVarFailIdx,
-                                   &fail_idx) == kOtbnOk);
-    LOG_INFO("ERROR: Test with index %d failed.", fail_idx);
+                                   &fail_idx) == kOtbnOk,
+          "ERROR: Test with index %d failed.", fail_idx);
     return false;
   }
 


### PR DESCRIPTION
Flash Partitions are Erased, Programmed and then Wiped by the RMA.  After the RMA has completed,
The test checks that SW Access to the FLASH is denied, and after a subsequent Reset, the Flash
is confirmed to be set to data other than that previously programmed.
Each run of the test performs 4 RMA cycles, seperated by a Reset.

There are TWO Issues of Interest that are associated with this PR.  I will add them as soon as I hve raised them.

Please Review for Merge